### PR TITLE
Deleted one needless symbol `//` at line 30

### DIFF
--- a/src/memerr.cpp
+++ b/src/memerr.cpp
@@ -27,7 +27,7 @@ void err_asan()
   int *k = fetch_mem();
   k[5] = 10;
 
-  // // double free
+  // double free
   int *l = new int[3];
   l[2] = 2;
   delete[] l;


### PR DESCRIPTION
The symbol `//` is needless, where comments of the `doule free pointer` has double symbols as `// //`.